### PR TITLE
fix sidekiq controller

### DIFF
--- a/app/controllers/sidekiq_api_controller.rb
+++ b/app/controllers/sidekiq_api_controller.rb
@@ -1,7 +1,5 @@
 class SidekiqApiController < ApplicationController
-  respond_to :json
-
   def index
-    respond_with Sidekiq::Stats.new
+    render json: Sidekiq::Stats.new
   end
 end


### PR DESCRIPTION
Removi a syntax antiga que eu uso no projeto que peguei de exemplo.
O json de output vai sair assim:
```
{
  "stats": {
    "processed": 0,
    "failed": 0,
    "scheduled_size": 0,
    "retry_size": 0,
    "dead_size": 0,
    "processes_size": 0,
    "default_queue_latency": 0,
    "workers_size": 0,
    "enqueued": 0
  }
}
```